### PR TITLE
Stable/17.02 add-private-space-binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,11 @@ The 'openstack-origin' setting allows Swift to be installed from installation
 repositories and can be used to setup access to the Ubuntu Cloud Archive
 to support installing Swift versions more recent than what is shipped with
 Ubuntu 12.04 (1.4.8).  For more information, see config.yaml.
+
+**Juju Spaces Awareness**
+
+The juju space binding for "private" has been added to the charm to allow
+for override of the unit's default private-address advertised to it's proxy
+relations.  This is done in case swift-storage units are landed on machines
+that have alternative networks defined that are not accessible from the
+swift-proxy units it is to be related with.

--- a/hooks/swift_storage_hooks.py
+++ b/hooks/swift_storage_hooks.py
@@ -48,6 +48,7 @@ from charmhelpers.core.hookenv import (
     relation_set,
     relations_of_type,
     status_set,
+    network_get_primary_address,
 )
 
 from charmhelpers.fetch import (
@@ -155,6 +156,12 @@ def swift_storage_relation_joined(rid=None):
     rel_settings['device'] = ':'.join(devs)
     # Keep a reference of devices we are adding to the ring
     remember_devices(devs)
+
+    # Fix for lp:1697491 - Assign "private" binding to network you
+    # wish to relate with swift-proxy on.  Fails back to unit def.
+    private_binding_address = network_get_primary_address('private')
+    if private_binding_address is not None:
+        rel_settings['private-address'] = private_binding_address
 
     if config('prefer-ipv6'):
         rel_settings['private-address'] = get_ipv6_addr()[0]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,7 +22,7 @@ series:
   - trusty
   - yakkety
 extra-bindings:
-  - private
+  private:
 provides:
   nrpe-external-master:
     interface: nrpe-external-master

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,6 +21,8 @@ series:
   - xenial
   - trusty
   - yakkety
+extra-bindings:
+  - private
 provides:
   nrpe-external-master:
     interface: nrpe-external-master


### PR DESCRIPTION
This is a backport of the add-private-space-binding feature previously PR'd that is being applied to tele2-sto1