### PR TITLE
edit *-server.conf to configure telegraf / localhost statsd listener

### DIFF
--- a/templates/account-server.conf
+++ b/templates/account-server.conf
@@ -2,6 +2,10 @@
 bind_ip = {{ bind_host }}
 bind_port = {{ account_server_port }}
 workers = {{ workers }}
+# enabling statsd metrics
+log_statsd_host = 127.0.0.1
+log_statsd_port = 8125
+log_statsd_default_sample_rate = 1
 
 [pipeline:main]
 pipeline = recon account-server
@@ -18,4 +22,3 @@ use = egg:swift#account
 [account-auditor]
 
 [account-reaper]
-

--- a/templates/container-server.conf
+++ b/templates/container-server.conf
@@ -2,6 +2,10 @@
 bind_ip = {{ bind_host }}
 bind_port = {{ container_server_port }}
 workers = {{ workers }}
+# enabling statsd metrics
+log_statsd_host = 127.0.0.1
+log_statsd_port = 8125
+log_statsd_default_sample_rate = 1
 
 [pipeline:main]
 pipeline = recon container-server
@@ -21,4 +25,3 @@ allow_versions = true
 [container-auditor]
 
 [container-sync]
-

--- a/templates/object-server.conf
+++ b/templates/object-server.conf
@@ -2,6 +2,10 @@
 bind_ip = {{ bind_host }}
 bind_port = {{ object_server_port }}
 workers = {{ workers }}
+# enabling statsd metrics
+log_statsd_host = 127.0.0.1
+log_statsd_port = 8125
+log_statsd_default_sample_rate = 1
 
 [pipeline:main]
 pipeline = recon object-server
@@ -23,4 +27,3 @@ rsync_timeout = {{ object_rsync_timeout }}
 [object-auditor]
 
 [object-sync]
-


### PR DESCRIPTION
This configures the server components (object, container, account) to send statsd packets via UDP to port 8125 on localhost. The intent is to configure the running telgraf server to listen for statsd on those ports, thus picking up the metrics to Promtheus.